### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Inline.php
+++ b/src/Inline.php
@@ -70,7 +70,7 @@ class Inline extends Plugin
 		self::$plugin = $this;
 
 		// Add in our Twig extensions
-		Craft::$app->view->twig->addExtension(new InlineTwigExtension());
+		Craft::$app->view->registerTwigExtension(new InlineTwigExtension());
 
 		// Do something after we're installed
 		Event::on(


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.